### PR TITLE
Added quiet_safari gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem 'sqreen', '>= 1.16'
 gem 'wicked_pdf'
 gem 'wkhtmltopdf-binary'
 gem 'rollbar'
-
+gem 'quiet_safari'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,6 +157,8 @@ GEM
     orm_adapter (0.5.0)
     pg (1.1.4)
     puma (3.12.1)
+    quiet_safari (1.0.0)
+      railties (>= 3.1.0)
     rack (2.0.7)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -277,6 +279,7 @@ DEPENDENCIES
   newrelic_rpm
   pg (>= 0.18, < 2.0)
   puma (~> 3.11)
+  quiet_safari
   rails (~> 5.2.3)
   rollbar
   sass-rails (~> 5.0)


### PR DESCRIPTION
This gem removes message 404 of favicons in safari