### PR TITLE
HotFix: Disable belongs_to required

### DIFF
--- a/config/initializers/rails_config.rb
+++ b/config/initializers/rails_config.rb
@@ -1,0 +1,1 @@
+Rails.application.config.active_record.belongs_to_required_by_default = false


### PR DESCRIPTION
This is a fix to disable belongs_to required by default, this is a new config on rails 5.
With this config on true, active admin could not generate new Playlists.